### PR TITLE
Fix/plugin issues

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,26 +4,29 @@ const importsPlugin = require('imports-plugin');
 /**
  * Defining the plugins this way is a workaround as the tailwind & the imports plugin wouldn't work otherwise when
  * installed together.
- * 
+ *
  * General info about the issue:
  *   - https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/31
  *   - https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9
- * 
+ *
  * Details about the workaround:
  *   - Base: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9#issuecomment-1021028722
  *   - Addition: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9#issuecomment-1157359437
  */
-const plugins = [{
-  parsers: {
-    typescript: {
-      ...tailwindPlugin.parsers.typescript,
-      preprocess: importsPlugin.parsers.typescript.preprocess,
+const plugins = [
+  {
+    parsers: {
+      typescript: {
+        ...tailwindPlugin.parsers.typescript,
+        preprocess: importsPlugin.parsers.typescript.preprocess,
+      },
+    },
+    options: {
+      ...tailwindPlugin.options,
+      ...importsPlugin.options,
     },
   },
-  options: {
-    ...importsPlugin.options,
-  },
-}];
+];
 
 /**
  * All options starting with 'importOrder' come from plugin `@trivago/prettier-plugin-sort-imports`.

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,30 @@
+const tailwindPlugin = require('tailwind-plugin');
+const importsPlugin = require('imports-plugin');
+
+/**
+ * Defining the plugins this way is a workaround as the tailwind & the imports plugin wouldn't work otherwise when
+ * installed together.
+ * 
+ * General info about the issue:
+ *   - https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/31
+ *   - https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9
+ * 
+ * Details about the workaround:
+ *   - Base: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9#issuecomment-1021028722
+ *   - Addition: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/9#issuecomment-1157359437
+ */
+const plugins = [{
+  parsers: {
+    typescript: {
+      ...tailwindPlugin.parsers.typescript,
+      preprocess: importsPlugin.parsers.typescript.preprocess,
+    },
+  },
+  options: {
+    ...importsPlugin.options,
+  },
+}];
+
 /**
  * All options starting with 'importOrder' come from plugin `@trivago/prettier-plugin-sort-imports`.
  */
@@ -11,6 +38,8 @@ module.exports = {
   printWidth: 120,
   trailingComma: 'es5',
   quoteProps: 'consistent',
+
+  plugins,
 
   importOrderSeparation: false,
   importOrderSortSpecifiers: true,

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ module.exports = {
 
 ### Included plugins
 
-This package with the following plugins pre-installed:
+This package comes with the following plugins pre-installed:
 
-* [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports)
+* [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports)  
   Options `importOrderSeparation` & `importOrderSortSpecifiers` are set to `true` by default here.
 * [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss)
 * [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ module.exports = {
 };
 ```
 
-### Import re-organization
+### Included plugins
 
-Comes with [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports) and therefore supports all customisation options of the plugin.
-Options `importOrderSeparation` & `importOrderSortSpecifiers` are set to `true` by default here.
+This package with the following plugins pre-installed:
+
+* [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports)
+  Options `importOrderSeparation` & `importOrderSortSpecifiers` are set to `true` by default here.
+* [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss)
+* [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)
+
+All options provided by those plugin can be adjusted using the method described above in section `Overwrite settings`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.3-rc2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/prettier-config",
-      "version": "0.0.3-rc2",
+      "version": "0.0.3",
       "license": "Apache 2.0",
       "peerDependencies": {
         "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.2",
+  "version": "0.0.3-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/prettier-config",
-      "version": "0.0.2",
+      "version": "0.0.3-rc1",
       "license": "Apache 2.0",
       "peerDependencies": {
         "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.2",
       "license": "Apache 2.0",
       "peerDependencies": {
-        "@trivago/prettier-plugin-sort-imports": "^3.2.0",
+        "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",
         "prettier": "^2.7.1",
-        "prettier-plugin-packagejson": "^2.2.18"
+        "prettier-plugin-packagejson": "^2.2.18",
+        "tailwind-plugin": "npm:prettier-plugin-tailwindcss@^0.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -577,24 +578,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@trivago/prettier-plugin-sort-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.2.0.tgz",
-      "integrity": "sha512-DnwLe+z8t/dZX5xBbYZV1+C5STkyK/P6SSq3Nk6NXlJZsgvDZX2eN4ND7bMFgGV/NL/YChWzcNf6ziGba1ktQQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "7.13.10",
-        "@babel/generator": "7.13.9",
-        "@babel/parser": "7.14.6",
-        "@babel/traverse": "7.13.0",
-        "@babel/types": "7.13.0",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "4.17.21"
-      },
-      "peerDependencies": {
-        "prettier": "2.x"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -965,6 +948,25 @@
         "node": ">= 4"
       }
     },
+    "node_modules/imports-plugin": {
+      "name": "@trivago/prettier-plugin-sort-imports",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.2.0.tgz",
+      "integrity": "sha512-DnwLe+z8t/dZX5xBbYZV1+C5STkyK/P6SSq3Nk6NXlJZsgvDZX2eN4ND7bMFgGV/NL/YChWzcNf6ziGba1ktQQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "7.13.10",
+        "@babel/generator": "7.13.9",
+        "@babel/parser": "7.14.6",
+        "@babel/traverse": "7.13.0",
+        "@babel/types": "7.13.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1299,6 +1301,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tailwind-plugin": {
+      "name": "prettier-plugin-tailwindcss",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.11.tgz",
+      "integrity": "sha512-a28+1jvpIZQdZ/W97wOXb6VqI762MKE/TxMMuibMEHhyYsSxQA8Ek30KObd5kJI2HF1ldtSYprFayXJXi3pz8Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
       }
     },
     "node_modules/to-fast-properties": {
@@ -1776,21 +1791,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@trivago/prettier-plugin-sort-imports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.2.0.tgz",
-      "integrity": "sha512-DnwLe+z8t/dZX5xBbYZV1+C5STkyK/P6SSq3Nk6NXlJZsgvDZX2eN4ND7bMFgGV/NL/YChWzcNf6ziGba1ktQQ==",
-      "peer": true,
-      "requires": {
-        "@babel/core": "7.13.10",
-        "@babel/generator": "7.13.9",
-        "@babel/parser": "7.14.6",
-        "@babel/traverse": "7.13.0",
-        "@babel/types": "7.13.0",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "4.17.21"
-      }
-    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -2067,6 +2067,21 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "peer": true
     },
+    "imports-plugin": {
+      "version": "npm:@trivago/prettier-plugin-sort-imports@3.2.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.2.0.tgz",
+      "integrity": "sha512-DnwLe+z8t/dZX5xBbYZV1+C5STkyK/P6SSq3Nk6NXlJZsgvDZX2eN4ND7bMFgGV/NL/YChWzcNf6ziGba1ktQQ==",
+      "peer": true,
+      "requires": {
+        "@babel/core": "7.13.10",
+        "@babel/generator": "7.13.9",
+        "@babel/parser": "7.14.6",
+        "@babel/traverse": "7.13.0",
+        "@babel/types": "7.13.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2298,6 +2313,13 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tailwind-plugin": {
+      "version": "npm:prettier-plugin-tailwindcss@0.1.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.11.tgz",
+      "integrity": "sha512-a28+1jvpIZQdZ/W97wOXb6VqI762MKE/TxMMuibMEHhyYsSxQA8Ek30KObd5kJI2HF1ldtSYprFayXJXi3pz8Q==",
+      "peer": true,
+      "requires": {}
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.3-rc1",
+  "version": "0.0.3-rc2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/prettier-config",
-      "version": "0.0.3-rc1",
+      "version": "0.0.3-rc2",
       "license": "Apache 2.0",
       "peerDependencies": {
         "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
     "pub-rc": "npm publish --tag rc"
   },
   "peerDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^3.2.0",
+    "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",
+    "tailwind-plugin": "npm:prettier-plugin-tailwindcss@^0.1.11",
     "prettier-plugin-packagejson": "^2.2.18",
     "prettier": "^2.7.1"
+  },
+  "peerDependenciesComments": {
+    "imports-plugin & tailwind-plugin": "We're using aliases to workaround a known issue with both plugins. See detailed info in `.prettierrc.js`"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.2",
+  "version": "0.0.3-rc1",
   "description": "",
   "main": ".prettierrc.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,32 +2,32 @@
   "name": "@combeenation/prettier-config",
   "version": "0.0.3-rc2",
   "description": "",
+  "bugs": {
+    "url": "https://github.com/Combeenation/cbn-prettier-config/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Combeenation/cbn-prettier-config"
+  },
+  "license": "Apache 2.0",
+  "author": "",
   "main": ".prettierrc.js",
   "files": [
     ".prettierrc.js",
     "package.json",
     "README.md"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Combeenation/cbn-prettier-config"
-  },
-  "bugs": {
-    "url": "https://github.com/Combeenation/cbn-prettier-config/issues"
-  },
-  "author": "",
-  "license": "Apache 2.0",
   "scripts": {
-    "pub-final": "npm publish",
     "pub-alpha": "npm publish --tag alpha",
     "pub-beta": "npm publish --tag beta",
+    "pub-final": "npm publish",
     "pub-rc": "npm publish --tag rc"
   },
   "peerDependencies": {
     "imports-plugin": "npm:@trivago/prettier-plugin-sort-imports@^3.2.0",
-    "tailwind-plugin": "npm:prettier-plugin-tailwindcss@^0.1.11",
+    "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.18",
-    "prettier": "^2.7.1"
+    "tailwind-plugin": "npm:prettier-plugin-tailwindcss@^0.1.11"
   },
   "peerDependenciesComments": {
     "imports-plugin & tailwind-plugin": "We're using aliases to workaround a known issue with both plugins. See detailed info in `.prettierrc.js`"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.3-rc2",
+  "version": "0.0.3",
   "description": "",
   "bugs": {
     "url": "https://github.com/Combeenation/cbn-prettier-config/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "0.0.3-rc1",
+  "version": "0.0.3-rc2",
   "description": "",
   "main": ".prettierrc.js",
   "files": [


### PR DESCRIPTION
The Tailwind & import order plugin have not been working correctly when installed together.
FAL found a workaround which registers the plugins in a different way.
I therefore changed our shared config now to also ship the Tailwind plugin directly.

Once you've approved this change, I'll publish a new final version and will directly commit the version update to the react-app repo in the UI improvements branch without an PR as this is pretty minor.