### PR TITLE
Update/proj structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   ```jsonc
   {
     // ...
-    "prettier": "@combeenation/prettier-config"
+    "prettier": "@combeenation/prettier-config",
   }
   ```
 - Remove existing prettier config files like `.prettierrc.json` etc.
@@ -24,23 +24,18 @@
 
 ## Overwrite settings
 
-This method does not offer a way to overwrite some properties from the shared configuration. In order to do so, one has to create a dedicated `.prettierrc.js` file and use node imports like this:
-
-```js
-module.exports = {
-  ...require("@combeenation/prettier-config"),
-  semi: false,
-};
-```
+This method does not offer a way to overwrite some properties from the shared configuration.
+In order to do so, remove the "prettier" configuration from the `package.json` and follow examples in the official prettier documentation:
+[Extending a Sharable Config](https://prettier.io/docs/sharing-configurations#extending-a-sharable-config)
 
 ### Included plugins
 
 This package comes with the following plugins pre-installed:
 
-* [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports)  
+- [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports)  
   Options `importOrderSeparation` & `importOrderSortSpecifiers` are set to `true` by default here.
-* [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss)
-* [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)
-* [@prettier/plugin-xml](https://www.npmjs.com/package/@prettier/plugin-xml)
+- [prettier-plugin-tailwindcss](https://www.npmjs.com/package/prettier-plugin-tailwindcss)
+- [prettier-plugin-packagejson](https://www.npmjs.com/package/prettier-plugin-packagejson)
+- [@prettier/plugin-xml](https://www.npmjs.com/package/@prettier/plugin-xml)
 
 All options provided by those plugin can be adjusted using the method described above in section `Overwrite settings`.

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
-module.exports = {
-  $schema: 'http://json.schemastore.org/prettierrc',
+const config = {
+  $schema: "http://json.schemastore.org/prettierrc",
   semi: true,
   singleQuote: true,
   bracketSpacing: true,
-  arrowParens: 'avoid',
-  endOfLine: 'auto',
+  arrowParens: "avoid",
+  endOfLine: "auto",
   printWidth: 120,
-  trailingComma: 'es5',
-  quoteProps: 'consistent',
+  trailingComma: "es5",
+  quoteProps: "consistent",
 
   plugins: [
     "@trivago/prettier-plugin-sort-imports",
     "@prettier/plugin-xml",
     "prettier-plugin-packagejson",
     // MUST come last, see [this](https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins)
-    "prettier-plugin-tailwindcss"
+    "prettier-plugin-tailwindcss",
   ],
 
   /**
    * Options from plugin `@prettier/plugin-xml`.
    * Why we need this: https://github.com/prettier/plugin-xml/issues/648.
    */
-  xmlWhitespaceSensitivity: 'ignore',
+  xmlWhitespaceSensitivity: "ignore",
 
   /**
    * Options from plugin `@trivago/prettier-plugin-sort-imports`.
@@ -29,3 +29,5 @@ module.exports = {
   importOrderSeparation: false,
   importOrderSortSpecifiers: true,
 };
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/prettier-config",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache 2.0",
       "peerDependencies": {
         "@prettier/plugin-xml": "^3.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/prettier-config",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache 2.0",
       "peerDependencies": {
         "@prettier/plugin-xml": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "license": "Apache 2.0",
   "author": "",
-  "main": ".prettierrc.js",
+  "exports": "./index.js",
+  "type": "module",
   "files": [
-    ".prettierrc.js",
-    "package.json",
-    "README.md"
+    "index.js",
+    "package.json"
   ],
   "scripts": {
     "pub-alpha": "npm publish --tag alpha",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "type": "module",
   "files": [
     "index.js",
-    "package.json"
+    "package.json",
+    "README.md"
   ],
   "scripts": {
     "pub-alpha": "npm publish --tag alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "bugs": {
     "url": "https://github.com/Combeenation/cbn-prettier-config/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/prettier-config",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "bugs": {
     "url": "https://github.com/Combeenation/cbn-prettier-config/issues"


### PR DESCRIPTION
Adjusted it a bit, so that it matches the suggested structure of the [Prettier docs](https://prettier.io/docs/sharing-configurations).
Related to [this commit](https://github.com/Combeenation/create-custom-code/pull/3/commits/2be8c67b0763da78e2432ad121037b98090e70d7) in `create-custom-code` so that consumer can override settings more easily.

_Based on the request from STO, to be able to override the prettier-config (e.g. increase `printWidth`)._